### PR TITLE
Add dubbo-go-hessian-registry generator.

### DIFF
--- a/cmd/dubbogo-cli-v2/README.md
+++ b/cmd/dubbogo-cli-v2/README.md
@@ -46,3 +46,98 @@ methods: []
 This command will generate a dubbo-go example, you can refer to the example [HOWTO](https://github.com/apache/dubbo-go-samples/blob/master/HOWTO.md) to run.
 
 ![img.png](docs/demo/img.png)
+
+
+### Add hessian2 registry statement
+#### main.go
+```go
+package main
+
+//go:generate go run "github.com/dubbogo/tools/cmd/dubbogo-cli-v2" hessian --include pkg
+func main() {
+
+}
+```
+#### pkg/demo.go
+
+```go
+package pkg
+
+type Demo0 struct {
+	A string `json:"a"`
+	B string `json:"b"`
+}
+
+func (*Demo0) JavaClassName() string {
+	return "org.apache.dubbo.Demo0"
+}
+
+type Demo1 struct {
+	C string `json:"c"`
+}
+
+func (*Demo1) JavaClassName() string {
+	return "org.apache.dubbo.Demo1"
+}
+
+```
+
+#### Execute `go generate`
+
+```shell
+go generate
+```
+
+#### Console logs
+```shell
+2022/01/28 11:58:11 === Generate start [pkg\demo.go] ===
+2022/01/28 11:58:11 === Registry POJO [pkg\demo.go].Demo0 ===
+2022/01/28 11:58:11 === Registry POJO [pkg\demo.go].Demo1 ===
+2022/01/28 11:58:11 === Generate completed [pkg\demo.go] ===
+```
+
+#### Result
+
+pkg/demo.go
+
+```go
+package pkg
+
+import (
+	"github.com/apache/dubbo-go-hessian2"
+)
+
+type Demo0 struct {
+	A string `json:"a"`
+	B string `json:"b"`
+}
+
+func (*Demo0) JavaClassName() string {
+	return "org.apache.dubbo.Demo0"
+}
+
+type Demo1 struct {
+	C string `json:"c"`
+}
+
+func (*Demo1) JavaClassName() string {
+	return "org.apache.dubbo.Demo1"
+}
+
+func init() {
+
+	hessian.RegisterPOJO(&Demo0{})
+
+	hessian.RegisterPOJO(&Demo1{})
+
+}
+
+```
+
+#### Command flags
+
+|  flag   |               description               |    default     |
+|:-------:|:---------------------------------------:|:--------------:|
+| include | Preprocess files parent directory path. |       ./       |
+| thread |          Worker thread limit.           | (cpu core) * 2 |
+| error |        Only print error message.        |     false      |

--- a/cmd/dubbogo-cli-v2/README_CN.md
+++ b/cmd/dubbogo-cli-v2/README_CN.md
@@ -46,3 +46,97 @@ methods: []
 该命令会生成一个 dubbo-go 的样例，该样例可以参考 [HOWTO](https://github.com/apache/dubbo-go-samples/blob/master/HOWTO.md) 运行:
 
 ![img.png](docs/demo/img.png)
+
+### 快速添加 hessian2 注册方法
+#### main.go
+```go
+package main
+
+//go:generate go run "github.com/dubbogo/tools/cmd/dubbogo-cli-v2" hessian --include pkg
+func main() {
+
+}
+```
+#### pkg/demo.go
+
+```go
+package pkg
+
+type Demo0 struct {
+	A string `json:"a"`
+	B string `json:"b"`
+}
+
+func (*Demo0) JavaClassName() string {
+	return "org.apache.dubbo.Demo0"
+}
+
+type Demo1 struct {
+	C string `json:"c"`
+}
+
+func (*Demo1) JavaClassName() string {
+	return "org.apache.dubbo.Demo1"
+}
+
+```
+
+#### 执行 `go generate`
+
+```shell
+go generate
+```
+
+#### 日志
+```shell
+2022/01/28 11:58:11 === Generate start [pkg\demo.go] ===
+2022/01/28 11:58:11 === Registry POJO [pkg\demo.go].Demo0 ===
+2022/01/28 11:58:11 === Registry POJO [pkg\demo.go].Demo1 ===
+2022/01/28 11:58:11 === Generate completed [pkg\demo.go] ===
+```
+
+#### 结果
+
+pkg/demo.go
+
+```go
+package pkg
+
+import (
+	"github.com/apache/dubbo-go-hessian2"
+)
+
+type Demo0 struct {
+	A string `json:"a"`
+	B string `json:"b"`
+}
+
+func (*Demo0) JavaClassName() string {
+	return "org.apache.dubbo.Demo0"
+}
+
+type Demo1 struct {
+	C string `json:"c"`
+}
+
+func (*Demo1) JavaClassName() string {
+	return "org.apache.dubbo.Demo1"
+}
+
+func init() {
+
+	hessian.RegisterPOJO(&Demo0{})
+
+	hessian.RegisterPOJO(&Demo1{})
+
+}
+
+```
+
+#### 命令行参数
+
+|  flag   |               description               |    default     |
+|:-------:|:---------------------------------------:|:--------------:|
+| include | Preprocess files parent directory path. |       ./       |
+| thread |          Worker thread limit.           | (cpu core) * 2 |
+| error |        Only print error message.        |     false      |

--- a/cmd/dubbogo-cli-v2/cmd/hessian.go
+++ b/cmd/dubbogo-cli-v2/cmd/hessian.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"runtime"
+)
+
+import (
+	"github.com/spf13/cobra"
+)
+
+import (
+	"github.com/dubbogo/tools/cmd/dubbogo-cli-v2/generator/sample"
+	"github.com/dubbogo/tools/cmd/dubbogo-cli-v2/generator/sample/hessian"
+)
+
+// hessianCmd represents the hessian-register-generator command
+var hessianCmd = &cobra.Command{
+	Use:   "hessian",
+	Short: "automatic generate hessian pojo register statement",
+	Run:   generateHessianRegistry,
+}
+
+func init() {
+	rootCmd.AddCommand(hessianCmd)
+	hessianCmd.Flags().StringP(hessian.CmdFlagInclude, "i", "./", "file scan directory path, default `./`")
+	hessianCmd.Flags().IntP(hessian.CmdFlagThread, "t", runtime.NumCPU()*2, "worker thread limit, default (cpu core) * 2")
+	hessianCmd.Flags().BoolP(hessian.CmdFlagOnlyError, "e", false, "only print error message, default false")
+}
+
+func generateHessianRegistry(cmd *cobra.Command, _ []string) {
+	var include string
+	var thread int
+	var onlyError bool
+	var err error
+
+	include, err = cmd.Flags().GetString(hessian.CmdFlagInclude)
+	if err != nil {
+		panic(err)
+	}
+
+	thread, err = cmd.Flags().GetInt(hessian.CmdFlagThread)
+	if err != nil {
+		panic(err)
+	}
+
+	onlyError, err = cmd.Flags().GetBool(hessian.CmdFlagOnlyError)
+	if err != nil {
+		panic(err)
+	}
+
+	if err = sample.HessianRegistryGenerate(include, thread, onlyError); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/dubbogo-cli-v2/generator/sample/hessian/constant.go
+++ b/cmd/dubbogo-cli-v2/generator/sample/hessian/constant.go
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hessian
+
+const (
+	CmdFlagInclude   = "include"
+	CmdFlagThread    = "thread"
+	CmdFlagOnlyError = "error"
+)
+
+const (
+	PackageRegexp = `^package\s[a-zA-Z_][0-9a-zA-Z_]*$`
+
+	LineCommentRegexp         = `\/\/`
+	MutLineCommentStartRegexp = `\/\*`
+	MutLineCommentEndRegexp   = `\*\/`
+
+	InitFunctionRegexp = `^func\sinit\(\)\s\{$`
+
+	HessianImportRegexp = `"github.com/apache/dubbo-go-hessian2"`
+
+	HessianPOJORegexp     = `\*[0-9a-zA-Z_]+\)\sJavaClassName\(\)\sstring\s\{$`
+	HessianPOJONameRegexp = `\*[0-9a-zA-Z_]+\)`
+)
+
+const (
+	newLine byte = '\n'
+	funcEnd byte = '}'
+
+	TargetFileSuffix = ".go"
+)

--- a/cmd/dubbogo-cli-v2/generator/sample/hessian/file_scanner.go
+++ b/cmd/dubbogo-cli-v2/generator/sample/hessian/file_scanner.go
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hessian
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ListFiles 获取目标目录下所有go文件
+func ListFiles(dirPath string, suffix string) (fileList []string, err error) {
+	suffix = strings.ToUpper(suffix)
+	fileList = make([]string, 0)
+	_, err = os.Lstat(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("找不到该目录[%s]", dirPath)
+	}
+	err = filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error { // 递归获取目录下所有go文件
+		if d == nil || d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(strings.ToUpper(d.Name()), suffix) {
+			fileList = append(fileList, path)
+		}
+		return nil
+	})
+	return
+}

--- a/cmd/dubbogo-cli-v2/generator/sample/hessian/generator.go
+++ b/cmd/dubbogo-cli-v2/generator/sample/hessian/generator.go
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hessian
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var (
+	hessianImport = []byte{newLine, 105, 109, 112, 111, 114, 116, 32, 40, newLine, 9, 34, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 97, 112, 97, 99, 104, 101, 47, 100, 117, 98, 98, 111, 45, 103, 111, 45, 104, 101, 115, 115, 105, 97, 110, 50, 34, newLine, 41, newLine}
+
+	initFunctionPrefix = []byte{newLine, 102, 117, 110, 99, 32, 105, 110, 105, 116, 40, 41, 32, 123, newLine}
+	initFunctionSuffix = []byte{newLine, funcEnd, newLine}
+
+	hessianRegistryPOJOFunctionPrefix = []byte{9, 104, 101, 115, 115, 105, 97, 110, 46, 82, 101, 103, 105, 115, 116, 101, 114, 80, 79, 74, 79, 40, 38}
+	hessianRegistryPOJOFunctionSuffix = []byte{123, funcEnd, 41}
+)
+
+type fileInfo struct {
+	path string
+
+	packageStartIndex int
+	packageEndIndex   int
+
+	hasInitFunc                 bool
+	initFuncStartIndex          int
+	initFuncEndIndex            int
+	initFuncStatementStartIndex int
+
+	hasHessianImport bool
+
+	buffer []byte
+
+	hessianPOJOList [][]byte
+}
+
+type Generator struct {
+	f string
+}
+
+func NewGenerator(f string) *Generator {
+	return &Generator{f}
+}
+
+func (g Generator) Execute() {
+	f := g.f
+	var file *fileInfo
+	var err error
+	showLog(infoLog, "=== Generate start [%s] ===", f)
+	file, err = scanFile(f)
+	if err != nil {
+		showLog(errorLog, "=== Generate error [%s] ===\n%v", f, err)
+		return
+	}
+	err = genRegistryStatement(file)
+	if err != nil {
+		showLog(errorLog, "=== Generate error [%s] ===\n%v", f, err)
+		return
+	}
+	showLog(infoLog, "=== Generate completed [%s] ===", f)
+}
+
+// scanFile 扫描文件内容
+func scanFile(filePath string) (file *fileInfo, err error) {
+	var f *os.File
+	f, err = os.Open(filePath)
+	if err != nil {
+		return
+	}
+	defer func(f *os.File) {
+		_ = f.Close()
+	}(f)
+	buf := bufio.NewReader(f)
+	file = &fileInfo{
+		path: filePath,
+	}
+	bufferSize := 0
+	buffer := make([]byte, bufferSize)
+	stack := make([][]byte, 0)
+	var line []byte
+	var lineSize int
+	for {
+		line, _, err = buf.ReadLine()
+		if err == io.EOF {
+			err = nil
+			break
+		}
+
+		bufferSize = len(buffer)
+		lineSize = len(line)
+
+		if file.hasInitFunc && lineSize > 0 && line[0] == funcEnd {
+			file.initFuncEndIndex = bufferSize + 1 // 检测初始化函数结束位
+		}
+
+		buffer = append(buffer, line...)
+		buffer = append(buffer, newLine)
+
+		if passed, _ := regexp.Match(PackageRegexp, line); passed { // 检测package位置
+			file.packageStartIndex = bufferSize              // 检测初始化函数初始位
+			file.packageEndIndex = bufferSize + lineSize + 1 // 检测初始化函数初始位
+			continue
+		}
+
+		if passed, _ := regexp.Match(InitFunctionRegexp, line); passed { // 检测初始化函数
+			file.hasInitFunc = true
+			file.initFuncStartIndex = bufferSize                     // 检测初始化函数初始位
+			file.initFuncStatementStartIndex = bufferSize + lineSize // 初始化函数方法体初始位
+			continue
+		}
+
+		if !file.hasHessianImport {
+			r, _ := regexp.Compile(HessianImportRegexp)
+			rIndexList := r.FindIndex(line)
+			if len(rIndexList) > 0 { // 检测是否已导入hessian2包
+				checkStatement := line[:rIndexList[0]]
+				passed, _ := regexp.Match(LineCommentRegexp, checkStatement) // 是否被行注释
+				file.hasHessianImport = !passed
+				continue
+			}
+		}
+
+		if passed, _ := regexp.Match(HessianPOJORegexp, line); !passed { // 校验是否为Hessian.POJO实现类
+			continue
+		}
+		structName := getStructName(line)
+		if len(structName) != 0 {
+			stack = append(stack, structName)
+		}
+	}
+	file.buffer = buffer
+	file.hessianPOJOList = stack
+	return
+}
+
+// getStructName 获取Hessian.POJO实现类的类名
+func getStructName(line []byte) []byte {
+	r, _ := regexp.Compile(HessianPOJONameRegexp)
+	line = r.Find(line)
+	if len(line) != 0 {
+		return line[1 : len(line)-1]
+	}
+	return nil
+}
+
+// genRegistryPOJOStatement 生成POJO注册方法体
+func genRegistryPOJOStatement(pojo []byte) []byte {
+	var buffer []byte
+	buffer = append(buffer, hessianRegistryPOJOFunctionPrefix...)
+	buffer = append(buffer, pojo...)
+	buffer = append(buffer, hessianRegistryPOJOFunctionSuffix...)
+	return buffer
+}
+
+func lastIndexOf(buf []byte, b byte, s *int) int {
+	var l int
+	if s != nil {
+		l = *s
+	} else {
+		l = len(buf)
+	}
+	if l < 0 || l >= len(buf) {
+		return -1
+	}
+	for ; l >= 0; l-- {
+		if buf[l] == b {
+			return l
+		}
+	}
+	return -1
+}
+
+func escape(str string) string {
+	str = strings.TrimSpace(str)
+	str = strings.ReplaceAll(str, ".", "\\.")
+	str = strings.ReplaceAll(str, "(", "\\(")
+	str = strings.ReplaceAll(str, ")", "\\)")
+	str = strings.ReplaceAll(str, "{", "\\{")
+	str = strings.ReplaceAll(str, "}", "\\}")
+	return str
+}
+
+// genRegistryPOJOStatements 生成POJO注册方法体
+func genRegistryPOJOStatements(file *fileInfo, initFunctionStatement *[]byte) []byte {
+	f := file.path
+	hessianPOJOList := file.hessianPOJOList
+	var buffer []byte
+	var r *regexp.Regexp
+	var rIndexList []int
+	for _, name := range hessianPOJOList {
+		statement := genRegistryPOJOStatement(name)
+		if initFunctionStatement != nil { // 检测是否已存在注册方法体
+			r, _ = regexp.Compile(escape(string(statement)))
+			initStatement := *initFunctionStatement
+			rIndexList = r.FindIndex(initStatement)
+			if len(rIndexList) > 0 {
+				i := rIndexList[0]
+				n := lastIndexOf(initStatement, newLine, &i)
+				checkStatement := initStatement[lastIndexOf(initStatement, newLine, &n)+1 : i]
+				if passed, _ := regexp.Match(LineCommentRegexp, checkStatement); !passed { // 是否被行注释
+					showLog(infoLog, "=== Ignore POJO [%s].%s ===", f, name)
+					continue // 忽略相同的注册操作
+				}
+			}
+		}
+
+		showLog(infoLog, "=== Registry POJO [%s].%s ===", f, name)
+
+		buffer = append(buffer, newLine)
+		buffer = append(buffer, statement...)
+		buffer = append(buffer, newLine)
+	}
+	return buffer
+}
+
+func genRegistryStatement(file *fileInfo) error {
+	if file == nil || len(file.hessianPOJOList) == 0 {
+		return nil
+	}
+	buffer := file.buffer
+
+	offset := 0
+
+	if !file.hasHessianImport { // 追加hessian2导包
+		sliceIndex := file.packageEndIndex + offset
+		var bufferClone []byte
+		bufferClone = append(bufferClone, buffer[:sliceIndex]...)
+		bufferClone = append(bufferClone, hessianImport...)
+		bufferClone = append(bufferClone, buffer[sliceIndex:]...)
+		buffer = bufferClone
+		offset += len(hessianImport)
+	}
+
+	var registryPOJOStatement []byte
+
+	if file.hasInitFunc {
+		sliceIndex := file.initFuncStatementStartIndex + offset
+		initFunctionStatement := buffer[sliceIndex : file.initFuncEndIndex+offset-1]
+		registryPOJOStatement = genRegistryPOJOStatements(file, &initFunctionStatement)
+		var bufferClone []byte
+		bufferClone = append(bufferClone, buffer[:sliceIndex]...)
+		bufferClone = append(bufferClone, registryPOJOStatement...) // 追加POJO注册方法体至init函数
+		bufferClone = append(bufferClone, buffer[sliceIndex:]...)
+		buffer = bufferClone
+	} else { // 追加初始化函数
+		registryPOJOStatement = genRegistryPOJOStatements(file, nil)
+		buffer = append(buffer, initFunctionPrefix...)    // 添加init函数
+		buffer = append(buffer, registryPOJOStatement...) // 追加POJO注册方法体至init函数
+		buffer = append(buffer, initFunctionSuffix...)
+	}
+
+	offset += len(registryPOJOStatement)
+
+	f, err := os.OpenFile(file.path, os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	defer func(f *os.File) {
+		_ = f.Close()
+	}(f)
+	_, err = f.Write(buffer)
+	return err
+}

--- a/cmd/dubbogo-cli-v2/generator/sample/hessian/logger.go
+++ b/cmd/dubbogo-cli-v2/generator/sample/hessian/logger.go
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hessian
+
+import (
+	"log"
+)
+
+type logType int
+
+const (
+	infoLog logType = iota
+	errorLog
+)
+
+var _onlyError = false
+
+// showLog 输出日志
+func showLog(t logType, format string, v ...interface{}) {
+	format = format + "\n"
+	if t == errorLog {
+		log.Fatalf(format, v...)
+		return
+	}
+	if _onlyError {
+		return
+	}
+	log.Printf(format, v...)
+}
+
+func ToggleLog(onlyError bool) {
+	_onlyError = onlyError
+}

--- a/cmd/dubbogo-cli-v2/generator/sample/hessian/pool.go
+++ b/cmd/dubbogo-cli-v2/generator/sample/hessian/pool.go
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hessian
+
+import (
+	"sync"
+)
+
+// Task 任务
+type Task interface {
+	Execute()
+}
+
+// Pool 线程池
+type Pool struct {
+	wg *sync.WaitGroup
+
+	taskQueue chan Task
+}
+
+func NewPool(max int) *Pool {
+	return &Pool{
+		wg:        &sync.WaitGroup{},
+		taskQueue: make(chan Task, max),
+	}
+}
+
+func (p Pool) Execute(t Task) {
+	p.wg.Add(1)
+	p.taskQueue <- t
+	go func() {
+		t.Execute()
+		<-p.taskQueue
+		p.wg.Done()
+	}()
+}
+
+func (p Pool) Wait() {
+	p.wg.Wait()
+}

--- a/cmd/dubbogo-cli-v2/generator/sample/hessian_generator.go
+++ b/cmd/dubbogo-cli-v2/generator/sample/hessian_generator.go
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample
+
+import (
+	"github.com/dubbogo/tools/cmd/dubbogo-cli-v2/generator/sample/hessian"
+)
+
+func HessianRegistryGenerate(includePath string, threadMax int, onlyError bool) error {
+	hessian.ToggleLog(onlyError)
+
+	fileList, err := hessian.ListFiles(includePath, hessian.TargetFileSuffix)
+	if err != nil {
+		return err
+	}
+
+	pool := hessian.NewPool(threadMax)
+	for _, f := range fileList {
+		pool.Execute(hessian.NewGenerator(f))
+	}
+	pool.Wait()
+	return nil
+}


### PR DESCRIPTION
Add dubbo-go-hessian-registry generator.

About [https://github.com/apache/dubbo-go/issues/1712](https://github.com/apache/dubbo-go/issues/1712) `减少registerPOJO的过程`





## Usage

### main.go

```go
package main

//go:generate go run "github.com/dubbogo/tools/cmd/dubbogo-cli-v2" hessian --include pkg
func main() {

}

```

### pkg/demo.go

```go
package pkg

type Demo0 struct {
	A string `json:"a"`
	B string `json:"b"`
}

func (*Demo0) JavaClassName() string {
	return "org.apache.dubbo.Demo0"
}

type Demo1 struct {
	C string `json:"c"`
}

func (*Demo1) JavaClassName() string {
	return "org.apache.dubbo.Demo1"
}

```

### Execute `go generate`

```shell
go generate
```

### Console logs
```shell
2022/01/28 11:58:11 === Generate start [pkg\demo.go] ===
2022/01/28 11:58:11 === Registry POJO [pkg\demo.go].Demo0 ===
2022/01/28 11:58:11 === Registry POJO [pkg\demo.go].Demo1 ===
2022/01/28 11:58:11 === Generate completed [pkg\demo.go] ===
```

### Result

pkg/demo.go

```go
package pkg

import (
	"github.com/apache/dubbo-go-hessian2"
)

type Demo0 struct {
	A string `json:"a"`
	B string `json:"b"`
}

func (*Demo0) JavaClassName() string {
	return "org.apache.dubbo.Demo0"
}

type Demo1 struct {
	C string `json:"c"`
}

func (*Demo1) JavaClassName() string {
	return "org.apache.dubbo.Demo1"
}

func init() {

	hessian.RegisterPOJO(&Demo0{})

	hessian.RegisterPOJO(&Demo1{})

}

```

## Command flags

|  flag   |               description               |    default     |
|:-------:|:---------------------------------------:|:--------------:|
| include | Preprocess files parent directory path. |       ./       |
| thread |          Worker thread limit.           | (cpu core) * 2 |
| error |        Only print error message.        |     false      |
