### PR TITLE
docs(deprecated): this repo is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# dubbo-go-cli
+This repository has been deprecated, move to [tools](https://github.com/apache/dubbo-go/tree/main/tools)
+
+# [Deprecated] dubbo-go-cli
 
 ### 1. Problem we solved.
 


### PR DESCRIPTION
This repo is deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prominent deprecation notice at the top of the README.
  * Updated the main heading to indicate the project is deprecated.
  * Included a link directing users to the new tools repository location.
  * Clarified that this change affects documentation only and does not alter functionality or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->